### PR TITLE
add image compression for uploads to optimize file size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4306,6 +4306,7 @@
 			"version": "1.0.17",
 			"resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-1.0.17.tgz",
 			"integrity": "sha512-TMDh3gyNlVA5Vvn0D0AdWr33s2ftIeokHK406z8cYlLJ4ANAq1x6eMaSzqedDoZwUGyTVB+0rhNVaSFgM3YAZg==",
+			"license": "MIT",
 			"dependencies": {
 				"core-js": "^3.16.1",
 				"uzip": "0.20201231.0"

--- a/src/lib/builder/components/Fields/FieldItem.svelte
+++ b/src/lib/builder/components/Fields/FieldItem.svelte
@@ -11,6 +11,7 @@
 	import PageFieldField from './PageFieldField.svelte'
 	import PageListField from './PageListField.svelte'
 	import SelectField from './SelectField.svelte'
+	import ImageFieldOptions from './ImageFieldOptions.svelte'
 	import fieldTypes from '../../stores/app/fieldTypes.js'
 	import { dynamic_field_types } from '$lib/builder/field-types'
 	import { pluralize } from '../../field-types/RepeaterField.svelte'
@@ -124,7 +125,7 @@
 
 	let is_new_field = $state(field.key === '')
 
-	let hide_footer = $derived(!['select', ...dynamic_field_types].includes(field.type) && !field.options.condition)
+	let hide_footer = $derived(!['select', 'image', ...dynamic_field_types].includes(field.type) && !field.options.condition)
 </script>
 
 <div class="top-container" class:top_level class:collapsed>
@@ -377,6 +378,12 @@
 					console.log({ updated_field })
 					dispatch_update(updated_field)
 				}}
+			/>
+		{/if}
+		{#if field.type === 'image'}
+			<ImageFieldOptions
+				{field}
+				on:input={({ detail }) => dispatch_update({ options: detail.options })}
 			/>
 		{/if}
 		{#if field.type === 'page-field'}

--- a/src/lib/builder/components/Fields/ImageFieldOptions.svelte
+++ b/src/lib/builder/components/Fields/ImageFieldOptions.svelte
@@ -1,0 +1,29 @@
+<script>
+	import UI from '../../ui/index.js'
+	import { createEventDispatcher } from 'svelte'
+
+	const dispatch = createEventDispatcher()
+
+	let { field } = $props()
+
+	// Initialize options object if it doesn't exist
+	if (!field.options) field.options = {}
+
+	// Set defaults if values don't exist
+	if (field.options.maxSizeMB === undefined) field.options.maxSizeMB = 1
+	if (field.options.maxWidthOrHeight === undefined) field.options.maxWidthOrHeight = 1920
+
+	// Listen for changes to dispatch updates to parent
+	function handle_change() {
+		dispatch('input', { options: field.options })
+	}
+</script>
+
+<div class="ImageFieldOptions">
+	<div class="option-group">
+		<UI.TextInput type="number" label="Max Size (MB)" bind:value={field.options.maxSizeMB} on:input={handle_change} />
+	</div>
+	<div class="option-group">
+		<UI.TextInput type="number" label="Max Dimension (px)" bind:value={field.options.maxWidthOrHeight} on:input={handle_change} />
+	</div>
+</div>

--- a/src/lib/builder/field-types/ImageField.svelte
+++ b/src/lib/builder/field-types/ImageField.svelte
@@ -33,10 +33,14 @@
 	async function upload_image(image) {
 		loading = true
 
+		// Get compression options from field config or use defaults
+		const maxSizeMB = field.options?.maxSizeMB ?? 1
+    	const maxWidthOrHeight = field.options?.maxWidthOrHeight ?? 1920
+
 		// Compression options
 		const options = {
-			maxSizeMB: 1, // Maximum size in MB
-			maxWidthOrHeight: 1920, // Resize large images to this dimension
+			maxSizeMB, // Maximum size in MB
+			maxWidthOrHeight, // Resize large images to this dimension
 			useWebWorker: true // Use web worker for better UI performance
 		}
 

--- a/src/lib/builder/field-types/ImageField.svelte
+++ b/src/lib/builder/field-types/ImageField.svelte
@@ -5,6 +5,7 @@
 	import Spinner from '../ui/Spinner.svelte'
 	import site from '../stores/data/site.js'
 	import { storageChanged } from '../database.js'
+	import imageCompression from 'browser-image-compression'
 
 	const default_value = {
 		alt: '',
@@ -32,7 +33,19 @@
 	async function upload_image(image) {
 		loading = true
 
-		await upload(image)
+		// Compression options
+		const options = {
+			maxSizeMB: 1, // Maximum size in MB
+			maxWidthOrHeight: 1920, // Resize large images to this dimension
+			useWebWorker: true // Use web worker for better UI performance
+		}
+
+		// Compress the image
+		const compressedImage = await imageCompression(image, options)
+		console.log(`Original size: ${image.size / 1024 / 1024} MB`)
+		console.log(`Compressed size: ${compressedImage.size / 1024 / 1024} MB`)
+
+		await upload(compressedImage)
 
 		async function upload(file) {
 			const key = `${$site.id}/${file.lastModified + file.name}`

--- a/src/lib/builder/views/editor/Layout/ComponentNode.svelte
+++ b/src/lib/builder/views/editor/Layout/ComponentNode.svelte
@@ -142,12 +142,13 @@
 					id: entry.id,
 					key: field.key,
 					value: entry.value,
-					type: field.type
+					type: field.type,
+					options: field.options
 				})
 			}
 		}
 
-		function search_elements_for_value({ id, key, value, type }) {
+		function search_elements_for_value({ id, key, value, type, options = {} }) {
 			for (const element of valid_elements) {
 				if (element.dataset['entry']) continue // element is already tagged, skip
 
@@ -156,7 +157,8 @@
 					key,
 					value,
 					type,
-					element
+					element,
+					options
 				})
 				if (matched) {
 					assigned_entry_ids.add(id)
@@ -165,7 +167,7 @@
 			}
 		}
 
-		function match_value_to_element({ id, element, key, value, type }) {
+		function match_value_to_element({ id, element, key, value, type, options = {} }) {
 			// if (value === '' || !value) return false
 
 			// ignore element
@@ -179,7 +181,7 @@
 				if (type === 'markdown') {
 					set_editable_markdown({ element, key, id })
 				} else if (type === 'image') {
-					set_editable_image({ element, id })
+					set_editable_image({ element, id, options })
 				} else if (type === 'link') {
 					set_editable_link({ element, id, url: value.url })
 				} else {
@@ -201,7 +203,7 @@
 			} else if (type === 'image' && element.nodeName === 'IMG') {
 				const image_matches = compare_urls(value.url, element.src)
 				if (image_matches) {
-					set_editable_image({ element, id })
+					set_editable_image({ element, id, options })
 					return true
 				}
 			} else if (type === 'markdown' && element.nodeName === 'DIV') {
@@ -289,7 +291,7 @@
 			})
 		}
 
-		async function set_editable_image({ element, id }) {
+		async function set_editable_image({ element, id, options }) {
 			let rect
 			element.setAttribute(`data-entry`, id)
 			element.onmousemove = (e) => {
@@ -319,6 +321,7 @@
 					}
 				}
 				image_editor.onclick = () => {
+					console.log(options)
 					modal.show('DIALOG', {
 						component: 'IMAGE',
 						onSubmit: ({ url, alt }) => {
@@ -331,7 +334,8 @@
 							value: {
 								url: element.src,
 								alt: element.alt
-							}
+							},
+							fieldOptions: options
 						}
 					})
 				}

--- a/src/lib/builder/views/modal/Dialogs/Image.svelte
+++ b/src/lib/builder/views/modal/Dialogs/Image.svelte
@@ -4,6 +4,7 @@
 	import Button from '$lib/builder/ui/Button.svelte'
 	import UI from '../../../ui'
 	import { storageChanged } from '../../../database'
+	import imageCompression from 'browser-image-compression'
 
 	let { value = {}, children, onsubmit } = $props()
 
@@ -31,15 +32,23 @@
 		if (files.length > 0) {
 			const image = files[0]
 
-			// const compressed = await imageCompression(image, {
-			// 	maxSizeMB: 0.5
-			// })
+			// Compression options
+			const options = {
+				maxSizeMB: 1, // Maximum size in MB
+				maxWidthOrHeight: 1920, // Resize large images to this dimension
+				useWebWorker: true // Use web worker for better UI performance
+			}
+
+			// Compress the image
+			const compressedImage = await imageCompression(image, options)
+			console.log(`Original size: ${image.size / 1024 / 1024} MB`)
+			console.log(`Compressed size: ${compressedImage.size / 1024 / 1024} MB`)
 
 			const key = `_images/${image.lastModified + image.name}`
 			const { url } = await storageChanged({
 				action: 'upload',
 				key,
-				file: image
+				file: compressedImage
 			})
 
 			if (url) {

--- a/src/lib/builder/views/modal/Dialogs/Image.svelte
+++ b/src/lib/builder/views/modal/Dialogs/Image.svelte
@@ -6,7 +6,7 @@
 	import { storageChanged } from '../../../database'
 	import imageCompression from 'browser-image-compression'
 
-	let { value = {}, children, onsubmit } = $props()
+	let { value = {}, children, onsubmit, fieldOptions = {} } = $props()
 
 	let imagePreview = $state(value?.url || '')
 	let local_value = $state({
@@ -34,9 +34,9 @@
 
 			// Compression options
 			const options = {
-				maxSizeMB: 1, // Maximum size in MB
-				maxWidthOrHeight: 1920, // Resize large images to this dimension
-				useWebWorker: true // Use web worker for better UI performance
+				maxSizeMB: fieldOptions.maxSizeMB ?? 1,
+				maxWidthOrHeight: fieldOptions.maxWidthOrHeight ?? 1920,
+				useWebWorker: true
 			}
 
 			// Compress the image


### PR DESCRIPTION
This pull request introduces image compression functionality to improve the performance and efficiency of image uploads in the `ImageField` and `Image` modal components. The most important changes include the addition of the `browser-image-compression` library and the implementation of image compression before uploading images.

Enhancements to image upload:

* [`src/lib/builder/field-types/ImageField.svelte`](diffhunk://#diff-86103a73689aba375cb3394cfdaa6cad5427bd4d62631a09ea15cbb65b0ddae7R8): Added the `browser-image-compression` library to compress images before uploading. Implemented compression options to limit the image size to 1 MB and resize large images to a maximum dimension of 1920 pixels. [[1]](diffhunk://#diff-86103a73689aba375cb3394cfdaa6cad5427bd4d62631a09ea15cbb65b0ddae7R8) [[2]](diffhunk://#diff-86103a73689aba375cb3394cfdaa6cad5427bd4d62631a09ea15cbb65b0ddae7L35-R48)
* [`src/lib/builder/views/modal/Dialogs/Image.svelte`](diffhunk://#diff-a0225c1ee7c021a5671e7b7d1b7be07bbd3985b5329d73bc4fc42b057bf78799R7): Integrated image compression using the `browser-image-compression` library in the image upload process within the modal dialog. Defined compression options similar to those in `ImageField.svelte`. [[1]](diffhunk://#diff-a0225c1ee7c021a5671e7b7d1b7be07bbd3985b5329d73bc4fc42b057bf78799R7) [[2]](diffhunk://#diff-a0225c1ee7c021a5671e7b7d1b7be07bbd3985b5329d73bc4fc42b057bf78799L34-R51)